### PR TITLE
Significantly modified build script to add a few options

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,3 +125,5 @@ else
 
     echo "Compiled and copied to current directory ($target)."
 fi
+
+# spiders 🕷️🕸️

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # Copyright © 2024 Jaxydog
+# Copyright © 2024 RemasteredArch
 #
 # This file is part of rs.
 #
@@ -12,17 +13,94 @@
 #
 # You should have received a copy of the GNU Affero General Public License along with rs. If not, see <https://www.gnu.org/licenses/>.
 
-if [ -d ./target/ ]; then
+set -euo pipefail # Quit upon any error or attempt to access unset variables
+
+text() {
+    local color_name="$1"
+    local color=""
+
+    case $color_name in
+        bold )
+            color="\e[1m"
+            ;;
+        dim | faint )
+            color="\e[2m"
+            ;;
+        reset | normal | * )
+            color="\e[0m"
+            ;;
+    esac
+
+
+    echo -e "$color"
+}
+
+opt() {
+    echo "$(text faint)$1$(text reset) | $(text faint)$2$(text reset)"
+}
+
+help() {
+    cat << EOF
+$(text bold)build.sh$(text reset): a build script for rs, a Rust replacement for ls(1).
+
+$(text bold)Arguments:$(text reset)
+  $(opt -h --help)     Displays this help message.
+  $(opt -i --install)  Installs to ~/.local/bin, or, if that doesn't exist,
+                     the current working directory.
+  $(opt -c --clean)    Runs \`cargo clean\` before building.
+EOF
+}
+
+args=""
+args=$(getopt \
+    --name "build.sh" \
+    --options i,c,h \
+    --longoptions install,clean,help \
+    -- "$@")
+
+eval set -- "$args"
+unset args
+
+declare -A opts
+opts[install]=false
+opts[clean]=false
+
+while true; do
+    case "$1" in
+        -i | --install )
+            opts[install]=true
+            shift
+            ;;
+        -c | --clean )
+            opts[clean]=true
+            shift
+            ;;
+        -h | --help )
+            help
+            exit 0
+            ;;
+        -- )
+            shift
+            break
+            ;;
+        * )
+            break
+            ;;
+    esac
+done
+
+
+if [ -d ./target/ ] && [ "${opts[clean]}" = true ]; then
     echo 'Cleaning up target directory.'
 
-    cargo clean || exit $?
+    cargo clean
 
     echo
 fi
 
 echo 'Building command binary.'
 
-cargo build --release || exit $?
+cargo build --release
 
 echo
 
@@ -32,12 +110,18 @@ if [ ! -f ./target/release/rs ]; then
     exit 1
 fi
 
-if [ -d ~/.local/bin/ ]; then
-    cp ./target/release/rs ~/.local/bin/rs
+if [ -d ~/.local/bin/ ] && [ "${opts[install]}" = true ]; then
+    target="$HOME/.local/bin/rs"
+    [ -f "$target" ] && rm "$target"
 
-    echo 'Compiled and copied to local programs.'
+    cp './target/release/rs' "$target"
+
+    echo "Compiled and copied to local programs ($target)."
 else
-    cp ./target/release/rs .
+    target="./rs"
+    [ -f "$target" ] && rm "$target"
 
-    echo 'Compiled and copied to current directory.'
+    cp './target/release/rs' "$target"
+
+    echo "Compiled and copied to current directory ($target)."
 fi


### PR DESCRIPTION
E.g.:
```
$ ./build.sh --help
build.sh: a build script for rs, a Rust replacement for ls(1).

Arguments:
  -h | --help     Displays this help message.
  -i | --install  Installs to ~/.local/bin, or, if that doesn't exist,
                     the current working directory.
  -c | --clean    Runs `cargo clean` before building.
  ```